### PR TITLE
Remove redundant code, since managed object has been saved already.

### DIFF
--- a/iCloudCoreDataStarter/ViewControllers/ThingViewController.swift
+++ b/iCloudCoreDataStarter/ViewControllers/ThingViewController.swift
@@ -98,7 +98,6 @@ class ThingViewController: UIViewController {
 
         let thingPrimitive = ThingPrimitive(amount: Int64(self.amountSlider.value), color: self.colorWell.selectedColor, thing: self.thing)
         let _ = Thing.upsertThingFromPrimitive(thingPrimitive)
-        CoreDataStack.shared.saveContext()
         self.dismiss(animated: true, completion: nil)
     }
 


### PR DESCRIPTION
Minor fix.